### PR TITLE
brew: setup shell completion

### DIFF
--- a/Formula/stackit.rb
+++ b/Formula/stackit.rb
@@ -16,6 +16,8 @@ This CLI is in a beta state. More services and functionality will be supported s
 
       def install
         bin.install "stackit"
+
+        generate_completions_from_executable(bin/"stackit", "completion")
       end
     end
     if Hardware::CPU.arm?
@@ -24,6 +26,8 @@ This CLI is in a beta state. More services and functionality will be supported s
 
       def install
         bin.install "stackit"
+
+        generate_completions_from_executable(bin/"stackit", "completion")
       end
     end
   end
@@ -36,6 +40,8 @@ This CLI is in a beta state. More services and functionality will be supported s
 
         def install
           bin.install "stackit"
+
+          generate_completions_from_executable(bin/"stackit", "completion")
         end
       end
     end
@@ -46,6 +52,8 @@ This CLI is in a beta state. More services and functionality will be supported s
 
         def install
           bin.install "stackit"
+
+          generate_completions_from_executable(bin/"stackit", "completion")
         end
       end
     end


### PR DESCRIPTION
This PR add the automatic setup of shell completion for StackIT CLI.

Docs: https://rubydoc.brew.sh/Formula#generate_completions_from_executable-instance_method

Ref for kubectl: https://github.com/Homebrew/homebrew-core/blob/33a3f1b400026561ff01cd8f7647a0503a06cbf7/Formula/k/kubernetes-cli.rb#L39C5-L39C41

Tested locally:

```
jok@jok-air ~ % curl https://raw.githubusercontent.com/jkroepke/homebrew-tap/refs/heads/patch-1/Formula/stackit.rb -O
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2007  100  2007    0     0   3778      0 --:--:-- --:--:-- --:--:--  3779
jok@jok-air ~ % brew install stackit.rb
Error: Failed to load cask: stackit.rb
Cask 'stackit' is unreadable: wrong constant name #<Class:0x00000001257233e8>
Warning: Treating stackit.rb as a formula.
==> Fetching stackit
==> Downloading https://github.com/stackitcloud/stackit-cli/releases/download/v0.26.0/stackit-cli_0.26.0_darwin_arm64.tar.gz
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/699237555/60f3124a-f258-4a4b-a1d6-9e17eaaf03db?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseas
##################################################################################################################################################################################################### 100.0%
==> Caveats
zsh completions have been installed to:
  /opt/homebrew/share/zsh/site-functions
==> Summary
🍺  /opt/homebrew/Cellar/stackit/0.26.0: 9 files, 41.3MB, built in 3 seconds
==> Running `brew cleanup stackit`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
```