### PR TITLE
chore: remove deprecated config `conflicts_with`

### DIFF
--- a/Casks/stackit.rb
+++ b/Casks/stackit.rb
@@ -36,9 +36,5 @@ This CLI is in a beta state. More services and functionality will be supported s
     end
   end
 
-  conflicts_with formula: [
-      "stackit",
-    ]
-
   # No zap stanza required
 end


### PR DESCRIPTION
relates to https://github.com/stackitcloud/stackit-cli/pull/945 and #5 